### PR TITLE
refactor(config): clean up config

### DIFF
--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -43,9 +43,6 @@ bwa_mem:
 bgzip_vcf:
   container: "docker://hydragenetics/common:0.1.8"
 
-decompose:
-  container: "docker://gmsuppsala/somatic:develop"
-
 fastp_pe:
    container: "docker://hydragenetics/fastp:0.20.1"
 

--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -108,10 +108,10 @@ pindel_call:
   extra: "-x 2 -B 60" #x och B?
 
 pindel2vcf:
-  refname: "'Genome Reference Consortium Human Build 37'"
-  refdate: "20xx"
   container: "docker://hydragenetics/pindel:0.2.5b9"
   extra: "-e 10 -mc 10 -is 5 -he 0.01 -G" # num reads support
+  refname: "hg19"
+  refdate: "2009"
 
 vardict:
   container: "docker://hydragenetics/vardict:1.8.3"

--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -29,9 +29,6 @@ bcbio_variation_recall_ensemble:
     - vardict
     - freebayes
 
-bed_split:
-  container: "docker://hydragenetics/common:0.1.8"
-
 bwa_mem:
   amb: "reference/FLT3.fasta.amb"
   ann: "reference/FLT3.fasta.ann"
@@ -40,29 +37,17 @@ bwa_mem:
   sa: "reference/FLT3.fasta.sa"
   container: "docker://hydragenetics/bwa_mem:0.7.17"
 
-bgzip_vcf:
-  container: "docker://hydragenetics/common:0.1.8"
-
 fastp_pe:
    container: "docker://hydragenetics/fastp:0.20.1"
 
 fastqc:
   container: "docker://hydragenetics/fastqc:0.11.9"
 
-fix_af:
-  container: "docker://hydragenetics/common:0.1.8"
-
 freebayes:
   container: "docker://hydragenetics/freebayes:1.3.1"
 
 mark_duplicates:
   container: "docker://hydragenetics/picard:2.25.0"
-
-merge_gvcf:
-  container: "docker://hydragenetics/common:0.1.8"
-
-merge_vcf:
-  container: "docker://hydragenetics/common:0.1.8"
 
 mosdepth_bed:
   container: "docker://hydragenetics/mosdepth:0.3.2"
@@ -132,15 +117,6 @@ pindel2vcf:
   refdate: "20xx"
   container: "docker://hydragenetics/pindel:0.2.5b9"
   extra: "-e 10 -mc 10 -is 5 -he 0.01 -G" # num reads support
-
-samtools_index:
-  container: "docker://hydragenetics/common:0.1.8"
-
-sort_vcf:
-  container: "docker://hydragenetics/common:0.1.8"
-
-tabix_vcf:
-  container: "docker://hydragenetics/common:0.1.8"
 
 vardict:
   container: "docker://hydragenetics/vardict:1.8.3"

--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -12,11 +12,6 @@ reference:
   fasta: "reference/FLT3.fasta"
   fai: "reference/FLT3.fasta.fai"
   dict: "reference/FLT3.dict"
-  amb: "reference/FLT3.fasta.amb"
-  ann: "reference/FLT3.fasta.ann"
-  bwt: "reference/FLT3.fasta.bwt"
-  pac: "reference/FLT3.fasta.pac"
-  sa: "reference/FLT3.fasta.sa"
   design_intervals: "data/bed/design.intervals"
   design_bed: "data/bed/design.bed"
   skip_chrs:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -43,9 +43,6 @@ bwa_mem:
 bgzip_vcf:
   container: "docker://hydragenetics/common:0.1.8"
 
-decompose:
-  container: "docker://gmsuppsala/somatic:develop"
-
 fastp_pe:
    container: "docker://hydragenetics/fastp:0.20.1"
 
@@ -144,7 +141,7 @@ tabix_vcf:
   container: "docker://hydragenetics/common:0.1.8"
 
 vardict:
-  container: "docker://gmsuppsala/somatic:develop"
+  container: "docker://hydragenetics/vardict:1.8.3"
   bed_columns: "-c 1 -S 2 -E 3"
 
 vt_decompose:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -12,11 +12,6 @@ reference:
   fasta: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.fasta"
   fai: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.fai"
   dict: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.dict"
-  amb: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.amb"
-  ann: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.ann"
-  bwt: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.bwt"
-  pac: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.pac"
-  sa: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.sa"
   design_intervals: "/projects/wp2/nobackup/Twist_Myeloid/Bed_files/Twist_myeloid_v.1.1_padd6_201126.sorted.intervals"
   design_bed: "/projects/wp2/nobackup/Twist_Myeloid/Bed_files/Twist_myeloid_v.1.1_padd6_201126.sorted.bed"
   skip_chrs:

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -110,6 +110,8 @@ pindel_call:
 pindel2vcf:
   container: "docker://hydragenetics/pindel:0.2.5b9"
   extra: "-e 10 -mc 10 -is 5 -he 0.01 -G" # num reads support
+  refname: "hg19"
+  refdate: "2009"
 
 vardict:
   container: "docker://hydragenetics/vardict:1.8.3"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -29,9 +29,6 @@ bcbio_variation_recall_ensemble:
     - vardict
     - freebayes
 
-bed_split:
-  container: "docker://hydragenetics/common:0.1.8"
-
 bwa_mem:
   amb: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.amb"
   ann: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.ann"
@@ -40,29 +37,17 @@ bwa_mem:
   sa: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.sa"
   container: "docker://hydragenetics/bwa_mem:0.7.17"
 
-bgzip_vcf:
-  container: "docker://hydragenetics/common:0.1.8"
-
 fastp_pe:
    container: "docker://hydragenetics/fastp:0.20.1"
 
 fastqc:
   container: "docker://hydragenetics/fastqc:0.11.9"
 
-fix_af:
-  container: "docker://hydragenetics/common:0.1.8"
-
 freebayes:
   container: "docker://hydragenetics/freebayes:1.3.1"
 
 mark_duplicates:
   container: "docker://hydragenetics/picard:2.25.0"
-
-merge_gvcf:
-  container: "docker://hydragenetics/common:0.1.8"
-
-merge_vcf:
-  container: "docker://hydragenetics/common:0.1.8"
 
 mosdepth_bed:
   container: "docker://hydragenetics/mosdepth:0.3.2"
@@ -130,15 +115,6 @@ pindel_call:
 pindel2vcf:
   container: "docker://hydragenetics/pindel:0.2.5b9"
   extra: "-e 10 -mc 10 -is 5 -he 0.01 -G" # num reads support
-
-samtools_index:
-  container: "docker://hydragenetics/common:0.1.8"
-
-sort_vcf:
-  container: "docker://hydragenetics/common:0.1.8"
-
-tabix_vcf:
-  container: "docker://hydragenetics/common:0.1.8"
 
 vardict:
   container: "docker://hydragenetics/vardict:1.8.3"


### PR DESCRIPTION
This PR refactors the config.

- Use only containers from hydra-genetics, closes #7 
- Remove config for rules where the only thing specifiec was the default container
- Remove duplicate bwa-mem references, closes #5 