### PR TITLE
refactor: update pindel call module

### DIFF
--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -103,9 +103,9 @@ picard_mark_duplicates:
   container: "docker://hydragenetics/picard:2.25.0"
 
 pindel_call:
-  bedfile: "data/bed/pindel_regions.bed"
   container: "docker://hydragenetics/pindel:0.2.5b9"
   extra: "-x 2 -B 60" #x och B?
+  include_bed: "data/bed/pindel_regions.bed"
 
 pindel2vcf:
   container: "docker://hydragenetics/pindel:0.2.5b9"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -103,9 +103,9 @@ picard_mark_duplicates:
   container: "docker://hydragenetics/picard:2.25.0"
 
 pindel_call:
-  bedfile: "/projects/wp2/nobackup/Twist_Myeloid/Bed_files/twist_shortlist_pindel-201214.bed"
   container: "docker://hydragenetics/pindel:0.2.5b9"
   extra: "-x 2 -B 60" #x och B?
+  include_bed: "/projects/wp2/nobackup/Twist_Myeloid/Bed_files/twist_shortlist_pindel-201214.bed"
 
 pindel2vcf:
   container: "docker://hydragenetics/pindel:0.2.5b9"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -49,7 +49,7 @@ use rule * from alignment as alignment_*
 
 module cnv_sv:
     snakefile:
-        github("hydra-genetics/cnv_sv", path="workflow/Snakefile", tag="66de5e8")
+        github("hydra-genetics/cnv_sv", path="workflow/Snakefile", tag="2daa54c")
     config:
         config
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -103,16 +103,14 @@ def compile_result_file_list():
     ]
 
     output_files += [
-        "results/cnv_sv/{0}.pindel.vcf".format(sample)
+        "results/cnv_sv/{0}_{1}.pindel.vcf".format(sample, unit_type)
         for sample in get_samples(samples)
         for unit_type in get_unit_types(units, sample)
-        if unit_type == "T"
     ]
     input_files += [
-        "cnv_sv/pindel/{0}.no_contig.vcf".format(sample)
+        "cnv_sv/pindel_vcf/{0}_{1}.no_contig.vcf".format(sample, unit_type)
         for sample in get_samples(samples)
         for unit_type in get_unit_types(units, sample)
-        if unit_type == "T"
     ]
 
     output_files.append("results/batchQC/MultiQC.html")


### PR DESCRIPTION
The pindel call wrapper has been updated, and now any bed files defining regions to include or exclude are now passed as inputs and not in `params.extra`. This fixes #8.