### PR TITLE
ci: fix linting workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,10 +22,23 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
-      - name: Linting
-        uses: snakemake/snakemake-github-action@v1.22.0
+      - name: Miniconda setup
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          directory: ".tests/integration"
-          snakefile: "workflow/Snakefile"
-          args: "--lint --configfile config/config.yaml"
-          stagein: "pip install -r requirements.txt"
+          python-version: 3.8
+          auto-update-conda: true
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+      - name: Install requirements
+        shell: bash -l {0}
+        run: |
+          pip install -r requirements.txt
+          mamba install -c conda-forge -c bioconda snakemake
+      - name: Linting
+        shell: bash -l {0}
+        working-directory: .tests/integration
+        run: |
+          snakemake -s ../../workflow/Snakefile \
+            --configfile config/config.yaml \
+            --lint


### PR DESCRIPTION
For some reason the pysam installation failed with the previous config.

Now the action seems to work as it should, but now it instead complains about path composition using `+` on a line of code that contains a regular expression. This is a [known issue](https://github.com/snakemake/snakemake/issues/902), so I will just ignore that this test fails for now.