### PR TITLE
feat: add cnvkit rules

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -40,5 +40,5 @@ jobs:
         working-directory: .tests/integration
         run: |
           snakemake -s ../../workflow/Snakefile \
-            --configfile config/config.yaml \
+            --configfile ../../config/config.yaml config/config.yaml \
             --lint

--- a/.github/workflows/snakemake-dry-run.yaml
+++ b/.github/workflows/snakemake-dry-run.yaml
@@ -41,4 +41,4 @@ jobs:
         working-directory: .tests/integration
         run: |
           mamba install -c conda-forge -c bioconda snakemake singularity
-          snakemake -n -s ../../workflow/Snakefile --configfile config/config.yaml
+          snakemake -n -s ../../workflow/Snakefile --configfile ../../config/config.yaml config/config.yaml

--- a/.tests/integration/config/config.yaml
+++ b/.tests/integration/config/config.yaml
@@ -1,29 +1,11 @@
 ---
 
-resources: "config/resources.yaml"
-samples: "samples.tsv"
-units: "units.tsv"
-
-default_container: "docker://hydragenetics/common:0.1.8"
-
-output_files: "config/output_files.yaml"
-trimmer_software: "fastp_pe"
-
 reference:
   fasta: "reference/FLT3.fasta"
   fai: "reference/FLT3.fasta.fai"
   dict: "reference/FLT3.dict"
   design_intervals: "data/bed/design.intervals"
   design_bed: "data/bed/design.bed"
-  skip_chrs:
-    - "chrM"
-
-bcbio_variation_recall_ensemble:
-  container: "docker://hydragenetics/bcbio-vc:0.2.6"
-  callers:
-    - gatk_mutect2
-    - vardict
-    - freebayes
 
 bwa_mem:
   amb: "reference/FLT3.fasta.amb"
@@ -31,95 +13,9 @@ bwa_mem:
   bwt: "reference/FLT3.fasta.bwt"
   pac: "reference/FLT3.fasta.pac"
   sa: "reference/FLT3.fasta.sa"
-  container: "docker://hydragenetics/bwa_mem:0.7.17"
 
-fastp_pe:
-   container: "docker://hydragenetics/fastp:0.20.1"
-
-fastqc:
-  container: "docker://hydragenetics/fastqc:0.11.9"
-
-freebayes:
-  container: "docker://hydragenetics/freebayes:1.3.1"
-
-mark_duplicates:
-  container: "docker://hydragenetics/picard:2.25.0"
-
-mosdepth_bed:
-  container: "docker://hydragenetics/mosdepth:0.3.2"
-
-multiqc:
-  container: "docker://hydragenetics/multiqc:1.11"
-  config: "config/multiqc.yaml"
-  reports:
-    DNA:
-      included_unit_types:
-        - T
-        - N
-      qc_files:
-        - "qc/fastqc/{sample}_{type}_{flowcell}_{lane}_{barcode}_{read}_fastqc.zip"
-        - "prealignment/fastp_pe/{sample}_{flowcell}_{lane}_{barcode}_{type}.json"
-        - "qc/mosdepth_bed/{sample}_{type}.mosdepth.summary.txt"
-        - "qc/mosdepth_bed/{sample}_{type}.per-base.bed.gz"
-        - "qc/picard_collect_hs_metrics/{sample}_{type}.HsMetrics.txt"
-        - "qc/picard_collect_alignment_summary_metrics/{sample}_{type}.alignment_summary_metrics.txt"
-        - "qc/picard_collect_duplication_metrics/{sample}_{type}.duplication_metrics.txt"
-        - "qc/picard_collect_insert_size_metrics/{sample}_{type}.insert_size_metrics.txt"
-        - "qc/picard_collect_gc_bias_metrics/{sample}_{type}.gc_bias.summary_metrics"
-        - "qc/samtools_stats/{sample}_{type}.samtools-stats.txt"
-
-gatk_mutect2:
-  container: "docker://hydragenetics/gatk4:4.1.9.0"
-
-gatk_mutect2_filter:
-  container: "docker://hydragenetics/gatk4:4.1.9.0"
-
-gatk_mutect2_gvcf:
-  container: "docker://hydragenetics/gatk4:4.1.9.0"
-
-gatk_mutect2_merge_stats:
-  container: "docker://hydragenetics/gatk4:4.1.9.0"
-
-picard_collect_alignment_summary_metrics:
-  container: "docker://hydragenetics/picard:2.25.0"
-
-picard_collect_duplication_metrics:
-  container: "docker://hydragenetics/picard:2.25.0"
-
-picard_collect_gc_bias_metrics:
-  container: "docker://hydragenetics/picard:2.25.0"
-
-picard_collect_hs_metrics:
-  container: "docker://hydragenetics/picard:2.25.0"
-
-picard_collect_insert_size_metrics:
-  container: "docker://hydragenetics/picard:2.25.0"
-
-picard_collect_multiple_metrics:
-  container: "docker://hydragenetics/picard:2.25.0"
-  output_ext:
-    - "insert_size_metrics"
-
-picard_mark_duplicates:
-  container: "docker://hydragenetics/picard:2.25.0"
+cnvkit_batch:
+  normal_reference: data/cnvkit/cnvkit_pon.cnn
 
 pindel_call:
-  container: "docker://hydragenetics/pindel:0.2.5b9"
-  extra: "-x 2 -B 60" #x och B?
   include_bed: "data/bed/pindel_regions.bed"
-
-pindel2vcf:
-  container: "docker://hydragenetics/pindel:0.2.5b9"
-  extra: "-e 10 -mc 10 -is 5 -he 0.01 -G" # num reads support
-  refname: "hg19"
-  refdate: "2009"
-
-vardict:
-  container: "docker://hydragenetics/vardict:1.8.3"
-  bed_columns: "-c 1 -S 2 -E 3"
-
-vt_decompose:
-  container: "docker://hydragenetics/vt:2015.11.10"
-
-vt_normalize:
-  container: "docker://hydragenetics/vt:2015.11.10"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -33,11 +33,25 @@ bwa_mem:
   sa: "/data/ref_genomes/hg19/bwa/BWA_0.7.10_refseq/hg19.with.mt.sa"
   container: "docker://hydragenetics/bwa_mem:0.7.17"
 
+cnvkit_batch:
+  container: "docker://hydragenetics/cnvkit:0.9.9"
+  normal_reference: ""
+  method: hybrid
+
+cnvkit_call:
+  container: "docker://hydragenetics/cnvkit:0.9.9"
+
+cnvkit_vcf:
+  container: "docker://hydragenetics/cnvkit:0.9.9"
+
 fastp_pe:
    container: "docker://hydragenetics/fastp:0.20.1"
 
 fastqc:
   container: "docker://hydragenetics/fastqc:0.11.9"
+
+filter_vcf:
+  germline: config/config_hard_filter_germline.yaml
 
 freebayes:
   container: "docker://hydragenetics/freebayes:1.3.1"
@@ -117,6 +131,12 @@ pindel2vcf:
 vardict:
   container: "docker://hydragenetics/vardict:1.8.3"
   bed_columns: "-c 1 -S 2 -E 3"
+
+vep:
+  container: docker://hydragenetics/vep:105
+  vep_cache: ""
+  mode: --offline --cache
+  extra: " --assembly GRCh37 --check_existing --pick --sift b --polyphen b --ccds --uniprot --hgvs --symbol --numbers --domains --regulatory --canonical --protein --biotype --uniprot --tsl --appris --gene_phenotype --af --af_1kg --af_gnomad --max_af --pubmed --variant_class "
 
 vt_decompose:
   container: "docker://hydragenetics/vt:2015.11.10"

--- a/config/config_hard_filter_germline.yaml
+++ b/config/config_hard_filter_germline.yaml
@@ -1,0 +1,13 @@
+filters:
+  germline:
+    description: "Hard filter germline"
+    expression: "(VEP:gnomAD_AF < 0.001)"
+    soft_filter: "False"
+  ad:
+    description: "Hard filter variants with few observations (AD lower than 50)"
+    expression: "(FORMAT:AD:1 < 50 or FORMAT:AD:0 < 50)"
+    soft_filter: "False"
+  snp_type:
+    description: "Hard filter variants that are not SNVs"
+    expression: "(!exist[SNV, VEP:VARIANT_CLASS])"
+    soft_filter: "False"

--- a/config/output_files.yaml
+++ b/config/output_files.yaml
@@ -23,3 +23,7 @@ files:
   - name: Pindel VCF file
     input: cnv_sv/pindel_vcf/{sample}_{type}.no_contig.vcf.gz
     output: vcf/{sample}_{type}.pindel.vcf.gz
+
+  - name: cnvkit vcf file
+    input: cnv_sv/cnvkit_vcf/{sample}_{type}.pathology.vcf
+    output: cnv/{sample}_{type}.pathology.cnvkit.vcf

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -46,14 +46,49 @@ module alignment:
 use rule * from alignment as alignment_*
 
 
+module annotation:
+    snakefile:
+        github(
+            "hydra-genetics/annotation",
+            path="workflow/Snakefile",
+            tag="v0.3.0",
+        )
+    config:
+        config
+
+
+use rule * from annotation as annotation_*
+
+
+module filtering:
+    snakefile:
+        github(
+            "hydra-genetics/filtering",
+            path="workflow/Snakefile",
+            tag="v0.1.0",
+        )
+    config:
+        config
+
+
+use rule * from filtering as filtering_*
+
+
 module cnv_sv:
     snakefile:
-        github("hydra-genetics/cnv_sv", path="workflow/Snakefile", tag="2daa54c")
+        github("hydra-genetics/cnv_sv", path="workflow/Snakefile", tag="v0.3.1")
     config:
         config
 
 
 use rule * from cnv_sv as cnv_sv_*
+
+
+use rule cnvkit_call from cnv_sv as cnv_sv_cnvkit_call with:
+    input:
+        segment="cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cns",
+        vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.vcf.gz",
+        tc_file=cnv_sv.get_tc_file,
 
 
 module qc:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -42,6 +42,13 @@ validate(samples, schema="../schemas/samples.schema.yaml")
 ### Read and validate units file
 units = pandas.read_table(config["units"], dtype=str).set_index(["sample", "type", "flowcell", "lane"], drop=False).sort_index()
 validate(units, schema="../schemas/units.schema.yaml")
+# Check that fastq files actually exist. If not, this might result in other
+# errors that can be hard to interpret
+for fq1, fq2 in zip(units["fastq1"].values, units["fastq2"].values):
+    if not pathlib.Path(fq1).exists():
+        sys.exit(f"fastq file not found: {fq1}\ncontrol the paths in {config['units']}")
+    if not pathlib.Path(fq2).exists():
+        sys.exit(f"fastq file not found: {fq2}\ncontrol the paths in {config['units']}")
 
 with open(config["output_files"], "r") as f:
     output_spec = yaml.safe_load(f.read())

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -29,10 +29,24 @@ min_version("7.13.0")
 if not workflow.overwrite_configfiles:
     sys.exit("At least one config file must be passed using --configfile/" "--configfiles, by command line or a profile!")
 
-validate(config, schema="../schemas/config.schema.yaml")
+try:
+    validate(config, schema="../schemas/config.schema.yaml")
+except WorkflowError as we:
+    # Probably a validation error, but the original exception in lost in
+    # snakemake. Pull out the most relevant information instead of a potentially
+    # *very* long error message.
+    if not we.args[0].lower().startswith("error validating config file"):
+        raise
+    error_msg = '\n'.join(we.args[0].splitlines()[:2])
+    parent_rule = we.args[0].splitlines()[3].split()[-1]
+    if parent_rule == "schema:":
+        sys.exit(error_msg)
+    else:
+        schema_hiearachy = parent_rule.split()[-1]
+        schema_section = ".".join(re.findall(r"\['([^']+)'\]", schema_hiearachy)[1::2])
+        sys.exit(f"{error_msg} in {schema_section}")
 config = load_resources(config, config["resources"])
 validate(config, schema="../schemas/resources.schema.yaml")
-
 
 ### Read and validate samples file
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -36,11 +36,11 @@ validate(config, schema="../schemas/resources.schema.yaml")
 
 ### Read and validate samples file
 
-samples = pd.read_table(config["samples"], dtype=str).set_index("sample", drop=False)
+samples = pd.read_table(config["samples"], dtype=str, comment="#").set_index("sample", drop=False)
 validate(samples, schema="../schemas/samples.schema.yaml")
 
 ### Read and validate units file
-units = pandas.read_table(config["units"], dtype=str).set_index(["sample", "type", "flowcell", "lane"], drop=False).sort_index()
+units = pandas.read_table(config["units"], dtype=str, comment="#").set_index(["sample", "type", "flowcell", "lane"], drop=False).sort_index()
 validate(units, schema="../schemas/units.schema.yaml")
 # Check that fastq files actually exist. If not, this might result in other
 # errors that can be hard to interpret

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -338,260 +338,262 @@ properties:
       - container
       - reports
 
-    gatk_mutect2:
-      type: object
-      description: >
-        Configuration for the gatk_mutect2 rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the gatk executable
-          format: uri-reference
-      required:
-        - container
+  gatk_mutect2:
+    type: object
+    description: >
+      Configuration for the gatk_mutect2 rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the gatk executable
+        format: uri-reference
+    required:
+      - container
 
-    gatk_mutect2_filter:
-      type: object
-      description: >
-        Configuration for the gatk_mutect2_filter rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the gatk executable
-          format: uri-reference
-      required:
-        - container
+  gatk_mutect2_filter:
+    type: object
+    description: >
+      Configuration for the gatk_mutect2_filter rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the gatk executable
+        format: uri-reference
+    required:
+      - container
 
-    gatk_mutect2_gvcf:
-      type: object
-      description: >
-        Configuration for the gatk_mutect2_gvcf rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the gatk executable
-          format: uri-reference
-      required:
-        - container
+  gatk_mutect2_gvcf:
+    type: object
+    description: >
+      Configuration for the gatk_mutect2_gvcf rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the gatk executable
+        format: uri-reference
+    required:
+      - container
 
-    gatk_mutect2_merge_stats:
-      type: object
-      description: >
-        Configuration for the gatk_mutect2_merge_stats rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the gatk executable
-          format: uri-reference
-      required:
-        - container
+  gatk_mutect2_merge_stats:
+    type: object
+    description: >
+      Configuration for the gatk_mutect2_merge_stats rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the gatk executable
+        format: uri-reference
+    required:
+      - container
 
-    picard_collect_alignment_summary_metrics:
-      type: object
-      description: >
-        Configuration for the picard_collect_alignment_summary_metrics rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the picard executable
-          format: uri-reference
-      required:
-        - container
+  picard_collect_alignment_summary_metrics:
+    type: object
+    description: >
+      Configuration for the picard_collect_alignment_summary_metrics rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the picard executable
+        format: uri-reference
+    required:
+      - container
 
-    picard_collect_duplication_metrics:
-      type: object
-      description: >
-        Configuration for the picard_collect_duplication_metrics rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the picard executable
-          format: uri-reference
-      required:
-        - container
+  picard_collect_duplication_metrics:
+    type: object
+    description: >
+      Configuration for the picard_collect_duplication_metrics rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the picard executable
+        format: uri-reference
+    required:
+      - container
 
-    picard_collect_gc_bias_metrics:
-      type: object
-      description: >
-        Configuration for the picard_collect_gc_bias_metrics rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the picard executable
-          format: uri-reference
-      required:
-        - container
+  picard_collect_gc_bias_metrics:
+    type: object
+    description: >
+      Configuration for the picard_collect_gc_bias_metrics rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the picard executable
+        format: uri-reference
+    required:
+      - container
 
-    picard_collect_hs_metrics:
-      type: object
-      description: >
-        Configuration for the picard_collect_hs_metrics rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the picard executable
-          format: uri-reference
-      required:
-        - container
+  picard_collect_hs_metrics:
+    type: object
+    description: >
+      Configuration for the picard_collect_hs_metrics rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the picard executable
+        format: uri-reference
+    required:
+      - container
 
-    picard_collect_insert_size_metrics:
-      type: object
-      description: >
-        Configuration for the picard_collect_insert_size_metrics rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the picard executable
-          format: uri-reference
-      required:
-        - container
+  picard_collect_insert_size_metrics:
+    type: object
+    description: >
+      Configuration for the picard_collect_insert_size_metrics rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the picard executable
+        format: uri-reference
+    required:
+      - container
 
-    picard_collect_multiple_metrics:
-      type: object
-      description: >
-        Configuration for the picard_collect_multiple_metrics rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the picard executable
-          format: uri-reference
-        output_ext:
+  picard_collect_multiple_metrics:
+    type: object
+    description: >
+      Configuration for the picard_collect_multiple_metrics rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the picard executable
+        format: uri-reference
+      output_ext:
+        type: array
+        items:
           type: string
           description: >
             Output extension
-      required:
-        - container
-        - output_ext
+    required:
+      - container
+      - output_ext
 
-    picard_mark_duplicates:
-      type: object
-      description: >
-        Configuration for the picard_mark_duplicates rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the picard executable
-          format: uri-reference
-      required:
-        - container
+  picard_mark_duplicates:
+    type: object
+    description: >
+      Configuration for the picard_mark_duplicates rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the picard executable
+        format: uri-reference
+    required:
+      - container
 
-    pindel_call:
-      type: object
-      description: >
-        Configuration for the pindel_call rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the pindel executable
-          format: uri-reference
-      required:
-        - container
+  pindel_call:
+    type: object
+    description: >
+      Configuration for the pindel_call rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the pindel executable
+        format: uri-reference
+    required:
+      - container
 
-    pindel2vcf:
-      type: object
-      description: >
-        Configuration for the pindel2vcf rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the pindel executable
-          format: uri-reference
-        refname:
-          type: string
-          description: >
-            Name of the reference genome
-        refdate:
-          type: string
-          description: >
-            Release date of the reference genome
-      required:
-        - container
+  pindel2vcf:
+    type: object
+    description: >
+      Configuration for the pindel2vcf rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the pindel executable
+        format: uri-reference
+      refname:
+        type: string
+        description: >
+          Name of the reference genome
+      refdate:
+        type: string
+        description: >
+          Release date of the reference genome
+    required:
+      - container
 
-    vardict:
-      type: object
-      description: >
-        Configuration for the vardict rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the vardict executable
-          format: uri-reference
-        bed_columns:
-          type: string
-          description: >
-            Command line options defining what columns in bed file to use
-      required:
-        - container
-        - bed_columns
+  vardict:
+    type: object
+    description: >
+      Configuration for the vardict rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the vardict executable
+        format: uri-reference
+      bed_columns:
+        type: string
+        description: >
+          Command line options defining what columns in bed file to use
+    required:
+      - container
+      - bed_columns
 
-    vep:
-      type: object
-      description: >
-        Configuration for the vep rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name of path to container containing the vep executable
-          format:
-            uri-reference
-        vep_cache:
-          type: string
-          description: >
-            Path to offline VEP cache
-          format: uri-reference
-        mode:
-          type: string
-          description: >
-            VEP arguments for run mode
-          examples:
-            - "--offline --cache"
-        extra:
-          type: string
-          description: >
-            Additional command line arguments for VEP
-      required:
-        - container
+  vep:
+    type: object
+    description: >
+      Configuration for the vep rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name of path to container containing the vep executable
+        format:
+          uri-reference
+      vep_cache:
+        type: string
+        description: >
+          Path to offline VEP cache
+        format: uri-reference
+      mode:
+        type: string
+        description: >
+          VEP arguments for run mode
+        examples:
+          - "--offline --cache"
+      extra:
+        type: string
+        description: >
+          Additional command line arguments for VEP
+    required:
+      - container
 
-    vt_decompose:
-      type: object
-      description: >
-        Configuration for the vt_decompose rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the vt executable
-          format: uri-reference
-      required:
-        - container
+  vt_decompose:
+    type: object
+    description: >
+      Configuration for the vt_decompose rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the vt executable
+        format: uri-reference
+    required:
+      - container
 
-    vt_normalize:
-      type: object
-      description: >
-        Configuration for the vt_normalize rule
-      properties:
-        container:
-          type: string
-          description: >
-            Name or path to container containing the vt executable
-          format: uri-reference
-      required:
-        - container
+  vt_normalize:
+    type: object
+    description: >
+      Configuration for the vt_normalize rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the vt executable
+        format: uri-reference
+    required:
+      - container
 
 required:
   - samples

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -132,6 +132,57 @@ properties:
       - sa
       - container
 
+  cnvkit_batch:
+    type: object
+    description: >
+      Configuration for the cnvkit_batch rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing cnvkit executable
+        format: uri-reference
+      normal_reference:
+        type: string
+        description: >
+          Path to cnvkit normal reference file (.cnn)
+        format: uri-reference
+        pattern: "\\.cnn$"
+      method:
+        type: string
+        description: >
+          Sequencing protocol used
+        enum:
+          - hybrid
+          - wgs
+          - amplicon
+    required:
+      - container
+      - normal_reference
+      - method
+
+  cnvkit_call:
+    type: object
+    description: >
+      Configuration for the cnvkit_call rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing cnvkit executable
+        format: uri-reference
+
+  cnvkit_vcf:
+    type: object
+    description: >
+      Configuration for the cnvkit_vcf rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing cnvkit executable
+        format: uri-reference
+
   bcbio_variation_recall_ensemble:
     type: object
     description: >
@@ -184,6 +235,19 @@ properties:
         format: uri-reference
     required:
       - container
+
+  filter_vcf:
+    type: object
+    description: >
+      Filter definitions for VCF files
+    properties:
+      germline:
+        type: string
+        description: >
+          Path to germline filter definition
+        format: uri-reference
+    required:
+      - germline
 
   freebayes:
     type: object
@@ -474,6 +538,35 @@ properties:
         - container
         - bed_columns
 
+    vep:
+      type: object
+      description: >
+        Configuration for the vep rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name of path to container containing the vep executable
+          format:
+            uri-reference
+        vep_cache:
+          type: string
+          description: >
+            Path to offline VEP cache
+          format: uri-reference
+        mode:
+          type: string
+          description: >
+            VEP arguments for run mode
+          examples:
+            - "--offline --cache"
+        extra:
+          type: string
+          description: >
+            Additional command line arguments for VEP
+      required:
+        - container
+
     vt_decompose:
       type: object
       description: >
@@ -510,8 +603,12 @@ required:
   - reference
   - bcbio_variation_recall_ensemble
   - bwa_mem
+  - cnvkit_batch
+  - cnvkit_call
+  - cnvkit_vcf
   - fastp_pe
   - fastqc
+  - filter_vcf
   - freebayes
   - mark_duplicates
   - mosdepth_bed
@@ -530,6 +627,7 @@ required:
   - pindel_call
   - pindel2vcf
   - vardict
+  - vep
   - vt_decompose
   - vt_normalize
 

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -2,18 +2,534 @@ $schema: "http://json-schema.org/draft-04/schema#"
 description: snakemake configuration file
 type: object
 properties:
+  # General config
   samples:
     type: string
+    description: >
+      Path to sample file
+    format: uri-reference
+
   units:
     type: string
+    description: >
+      Path to units file
+    format: uri-reference
+
   resources:
     type: string
-    description: Path to resources.yaml file
+    description: >
+      Path to resources.yaml file
+    format: uri-reference
+
+  output_files:
+    type: string
+    description: >
+      Path to file defining workflow output files
+    format: uri-reference
+
   default_container:
     type: string
-    description: name or path to a default docker/singularity container
-  required:
-    - samples
-    - units
-    - resources
-    - default_container
+    description: >
+      Name or path to a default docker/singularity container
+    format: uri-reference
+
+  trimmer_software:
+    type: string
+    description: >
+      Trimmer software to use
+
+  # General genome reference files
+  reference:
+    type: object
+    description: >
+      Reference genome files
+    properties:
+      fasta:
+        type: string
+        description: >
+          Path to genome fasta file
+        format: uri-reference
+
+      fai:
+        type: string
+        description: >
+          Path to genome fasta file index
+        format: uri-reference
+
+      dict:
+        type: string
+        description: >
+          Path to genome sequence dict file
+        format: uri-reference
+
+      design_bed:
+        type: string
+        description: >
+          Path to bed file containing panel design
+        format: uri-reference
+
+      design_intervals:
+        type: string
+        description: >
+          Path to panel design interval file
+        format: uri-reference
+
+      skip_chrs:
+        type: array
+        description: >
+          Reference sequences that should be excluded from analysis
+        items:
+          type: string
+
+    required:
+      - fasta
+      - fai
+      - dict
+      - design_bed
+      - design_intervals
+
+  # Rule-specific configs
+  bwa_mem:
+    type: object
+    description: >
+      Configuration for the bwa_mem rule
+    properties:
+      amb:
+        type: string
+        description: bwa amb file
+        format: uri-reference
+        pattern: "\\.amb$"
+      ann:
+        type: string
+        description: bwa ann file
+        format: uri-reference
+        pattern: "\\.ann$"
+      bwt:
+        type: string
+        description: bwa bwt file
+        format: uri-reference
+        pattern: "\\.bwt$"
+      pac:
+        type: string
+        description: bwa bwt file
+        format: uri-reference
+        pattern: "\\.pac$"
+      sa:
+        type: string
+        description: bwa bwt file
+        format: uri-reference
+        pattern: "\\.sa$"
+      container:
+        type: string
+        description: >
+          Name or path to container containing bwa executable
+        format: uri-reference
+    required:
+      - amb
+      - ann
+      - bwt
+      - pac
+      - sa
+      - container
+
+  bcbio_variation_recall_ensemble:
+    type: object
+    description: >
+      Configuration for the bcbio_variation_recall_ensemble rule
+    properties:
+      callers:
+        type: array
+        description: >
+          Callers from which results should be ensembled
+        items:
+          type: string
+          description: >
+            Name of the caller to use
+          enum:
+            - gatk_mutect2
+            - vardict
+            - freebayes
+        minItems: 1
+      container:
+        type: string
+        description: >
+          Name or path to container containing the bcbio_variation_recall executable
+        format: uri-reference
+    required:
+      - callers
+      - container
+
+  fastp_pe:
+    type: object
+    description: >
+      Config for the fastp_pe rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the fastp executable
+        format: uri-reference
+    required:
+      - container
+
+  fastqc:
+    type: object
+    description: >
+      Config for the fastqc rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the fastqc executable
+        format: uri-reference
+    required:
+      - container
+
+  freebayes:
+    type: object
+    description: >
+      Config for the freebayes rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the freebayes executable
+        format: uri-reference
+    required:
+      - container
+
+  mark_duplicates:
+    type: object
+    description: >
+      Config for the mark_duplicates rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the picard executable
+        format: uri-reference
+    required:
+      - container
+
+  mosdepth_bed:
+    type: object
+    description: >
+      Config for the mosdepth_bed rule
+    properties:
+      container:
+        type: string
+        description: >
+          Name or path to container containing the mosdepth executable
+        format: uri-reference
+    required:
+      - container
+
+  multiqc:
+    type: object
+    description: >
+      Config for the multiqc rule
+    properties:
+      config:
+        type: string
+        description: > 
+          Path to multiqc config file
+        format: uri-reference
+      container:
+        type: string
+        description: >
+          Name or path to container containing the multiqc executable
+        format: uri-reference
+      reports:
+        type: object
+        description: >
+          Logs that should be included in the multiqc report
+        properties:
+          DNA:
+            type: object
+            properties:
+              included_unit_types:
+                type: array
+                description: >
+                  Unit types that should be included
+                items:
+                  type: string
+                  enum:
+                    - T
+                    - N
+              qc_files:
+                type: array
+                description: >
+                  Log files to include. Variables from the samples and units
+                  files can be used in the file names.
+                items:
+                  type: string
+                  format: uri-reference
+            required:
+              - included_unit_types
+              - qc_files
+        required:
+          - DNA
+    required:
+      - config
+      - container
+      - reports
+
+    gatk_mutect2:
+      type: object
+      description: >
+        Configuration for the gatk_mutect2 rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the gatk executable
+          format: uri-reference
+      required:
+        - container
+
+    gatk_mutect2_filter:
+      type: object
+      description: >
+        Configuration for the gatk_mutect2_filter rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the gatk executable
+          format: uri-reference
+      required:
+        - container
+
+    gatk_mutect2_gvcf:
+      type: object
+      description: >
+        Configuration for the gatk_mutect2_gvcf rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the gatk executable
+          format: uri-reference
+      required:
+        - container
+
+    gatk_mutect2_merge_stats:
+      type: object
+      description: >
+        Configuration for the gatk_mutect2_merge_stats rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the gatk executable
+          format: uri-reference
+      required:
+        - container
+
+    picard_collect_alignment_summary_metrics:
+      type: object
+      description: >
+        Configuration for the picard_collect_alignment_summary_metrics rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the picard executable
+          format: uri-reference
+      required:
+        - container
+
+    picard_collect_duplication_metrics:
+      type: object
+      description: >
+        Configuration for the picard_collect_duplication_metrics rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the picard executable
+          format: uri-reference
+      required:
+        - container
+
+    picard_collect_gc_bias_metrics:
+      type: object
+      description: >
+        Configuration for the picard_collect_gc_bias_metrics rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the picard executable
+          format: uri-reference
+      required:
+        - container
+
+    picard_collect_hs_metrics:
+      type: object
+      description: >
+        Configuration for the picard_collect_hs_metrics rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the picard executable
+          format: uri-reference
+      required:
+        - container
+
+    picard_collect_insert_size_metrics:
+      type: object
+      description: >
+        Configuration for the picard_collect_insert_size_metrics rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the picard executable
+          format: uri-reference
+      required:
+        - container
+
+    picard_collect_multiple_metrics:
+      type: object
+      description: >
+        Configuration for the picard_collect_multiple_metrics rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the picard executable
+          format: uri-reference
+        output_ext:
+          type: string
+          description: >
+            Output extension
+      required:
+        - container
+        - output_ext
+
+    picard_mark_duplicates:
+      type: object
+      description: >
+        Configuration for the picard_mark_duplicates rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the picard executable
+          format: uri-reference
+      required:
+        - container
+
+    pindel_call:
+      type: object
+      description: >
+        Configuration for the pindel_call rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the pindel executable
+          format: uri-reference
+      required:
+        - container
+
+    pindel2vcf:
+      type: object
+      description: >
+        Configuration for the pindel2vcf rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the pindel executable
+          format: uri-reference
+        refname:
+          type: string
+          description: >
+            Name of the reference genome
+        refdate:
+          type: string
+          description: >
+            Release date of the reference genome
+      required:
+        - container
+
+    vardict:
+      type: object
+      description: >
+        Configuration for the vardict rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the vardict executable
+          format: uri-reference
+        bed_columns:
+          type: string
+          description: >
+            Command line options defining what columns in bed file to use
+      required:
+        - container
+        - bed_columns
+
+    vt_decompose:
+      type: object
+      description: >
+        Configuration for the vt_decompose rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the vt executable
+          format: uri-reference
+      required:
+        - container
+
+    vt_normalize:
+      type: object
+      description: >
+        Configuration for the vt_normalize rule
+      properties:
+        container:
+          type: string
+          description: >
+            Name or path to container containing the vt executable
+          format: uri-reference
+      required:
+        - container
+
+required:
+  - samples
+  - units
+  - resources
+  - output_files
+  - default_container
+  - trimmer_software
+  - reference
+  - bcbio_variation_recall_ensemble
+  - bwa_mem
+  - fastp_pe
+  - fastqc
+  - freebayes
+  - mark_duplicates
+  - mosdepth_bed
+  - multiqc
+  - gatk_mutect2
+  - gatk_mutect2_filter
+  - gatk_mutect2_gvcf
+  - gatk_mutect2_merge_stats
+  - picard_collect_alignment_summary_metrics
+  - picard_collect_duplication_metrics
+  - picard_collect_gc_bias_metrics
+  - picard_collect_hs_metrics
+  - picard_collect_insert_size_metrics
+  - picard_collect_multiple_metrics
+  - picard_mark_duplicates
+  - pindel_call
+  - pindel2vcf
+  - vardict
+  - vt_decompose
+  - vt_normalize
+


### PR DESCRIPTION
This PR adds cnvkit to the pipeline. In addition, germline filtering of SNV VCFs were added, as well as VEP annotation. In an effort to minimise the number of runtime errors, the validation schema for the config was fleshed out quite a bit.