### PR TITLE
feat: add reference file workflow

### DIFF
--- a/config/config_references.yaml
+++ b/config/config_references.yaml
@@ -17,3 +17,9 @@ cnvkit_create_targets:
 
 cnvkit_create_anti_targets:
   container: docker://hydragenetics/cnvkit:0.9.9
+
+svdb_build:
+  container: docker://hydragenetics/svdb:2.6.0
+
+svdb_export:
+  container: docker://hydragenetics/svdb:2.6.0

--- a/config/config_references.yaml
+++ b/config/config_references.yaml
@@ -1,6 +1,6 @@
 samples: samples_references.tsv
 units: units_references.tsv
-resources: config_dev/resources_references.yaml
+resources: config/resources_references.yaml
 
 default_container: docker://hydragenetics/common:0.1.9
 

--- a/config/config_references.yaml
+++ b/config/config_references.yaml
@@ -1,0 +1,19 @@
+samples: samples_references.tsv
+units: units_references.tsv
+resources: config_dev/resources_references.yaml
+
+default_container: docker://hydragenetics/common:0.1.9
+
+reference:
+  fasta: "/home/nima18/twist-hematology-reference-testenv/hg19/hg19.with.mt.fasta"
+  design_bed: "/storage/userdata/references/homo_sapiens/hg19/hydra-genetics/twist-hematology-dna/bed/all_targets_covered_twist_myeloid_v2_hg19_sorted_merge_padded10_annot.bed"
+  mappability: "/storage/userdata/references/homo_sapiens/hg19/hydra-genetics/twist-solid-dna/bed/access-5k-mappable.hg19.bed"
+
+cnvkit_build_normal_reference:
+  container: docker://hydragenetics/cnvkit:0.9.9
+
+cnvkit_create_targets:
+  container: docker://hydragenetics/cnvkit:0.9.9
+
+cnvkit_create_anti_targets:
+  container: docker://hydragenetics/cnvkit:0.9.9

--- a/config/config_references.yaml
+++ b/config/config_references.yaml
@@ -7,7 +7,11 @@ default_container: docker://hydragenetics/common:0.1.9
 reference:
   fasta: "/home/nima18/twist-hematology-reference-testenv/hg19/hg19.with.mt.fasta"
   design_bed: "/storage/userdata/references/homo_sapiens/hg19/hydra-genetics/twist-hematology-dna/bed/all_targets_covered_twist_myeloid_v2_hg19_sorted_merge_padded10_annot.bed"
+  dict: /home/nima18/twist-hematology-reference-testenv/hg19/hg19.with.mt.dict
   mappability: "/storage/userdata/references/homo_sapiens/hg19/hydra-genetics/twist-solid-dna/bed/access-5k-mappable.hg19.bed"
+
+bed_to_interval_list:
+  container: docker://hydragenetics/gatk4:4.2.2.0
 
 cnvkit_build_normal_reference:
   container: docker://hydragenetics/cnvkit:0.9.9
@@ -17,6 +21,15 @@ cnvkit_create_targets:
 
 cnvkit_create_anti_targets:
   container: docker://hydragenetics/cnvkit:0.9.9
+
+collect_read_counts:
+  container: docker://hydragenetics/gatk4:4.2.2.0
+
+create_read_count_panel_of_normals:
+  container: docker://hydragenetics/gatk4:4.2.2.0
+
+preprocess_intervals:
+  container: docker://hydragenetics/gatk4:4.2.2.0
 
 svdb_build:
   container: docker://hydragenetics/svdb:2.6.0

--- a/resources_references.yaml
+++ b/resources_references.yaml
@@ -1,0 +1,9 @@
+default_resources:
+  threads: 1
+  time: "1:00:00"
+  mem_mb: 1024
+  mem_per_cpu: 1024
+  partition: core
+
+cnvkit_build_normal_reference:
+  threads: 8

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -76,7 +76,7 @@ use rule * from filtering as filtering_*
 
 module cnv_sv:
     snakefile:
-        github("hydra-genetics/cnv_sv", path="workflow/Snakefile", tag="v0.3.1")
+        github("hydra-genetics/cnv_sv", path="workflow/Snakefile", tag="549ff36")
     config:
         config
 

--- a/workflow/Snakefile_references.smk
+++ b/workflow/Snakefile_references.smk
@@ -1,0 +1,20 @@
+include: "rules/common_references.smk"
+include: "rules/result_files_references.smk"
+
+rule all:
+    input:
+        compile_output_list,
+
+
+module references:
+    snakefile:
+        github(
+            repo="hydra-genetics/references",
+            path="workflow/Snakefile",
+            tag="e024089",
+        )
+    config:
+        config
+
+
+use rule * from references as references_*

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -25,11 +25,6 @@ def compile_output_list(wildcards: snakemake.io.Wildcards):
     return [
         "reference_files/cnvkit.PoN.cnn",
         "reference_files/gatk.PoN.hdf5",
-        # "reference_files/Msisensor_pro_reference.list_baseline",
-        # "reference_files/background_panel.tsv",
-        # "reference_files/artifact_panel.tsv",
         "reference_files/svdb_cnv.vcf",
         "reference_files/{}.preprocessed.interval_list".format(Path(config.get("reference", {}).get("design_bed")).name),
-        # "reference_files/normalDB_hg19.rds",
-        # "reference_files/mapping_bias_nextseq_27_hg19.rds",
     ]

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -23,7 +23,7 @@ validate(units, schema="../schemas/units_references.schema.yaml")
 def compile_output_list(wildcards: snakemake.io.Wildcards):
     return [
         "reference_files/cnvkit.PoN.cnn",
-        # "reference_files/gatk_cnv_panel_of_normal.hdf5",
+        "reference_files/gatk.PoN.hdf5",
         # "reference_files/Msisensor_pro_reference.list_baseline",
         # "reference_files/background_panel.tsv",
         # "reference_files/artifact_panel.tsv",

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -1,0 +1,33 @@
+import pandas as pd
+from snakemake.utils import validate
+from snakemake.utils import min_version
+import sys
+
+from hydra_genetics.utils.resources import load_resources
+
+if not workflow.overwrite_configfiles:
+    sys.exit("config file has to be specified with --configfile")
+
+# Validate config
+validate(config, schema="../schemas/config_references.schema.yaml")
+config = load_resources(config, config["resources"])
+validate(config, schema="../schemas/resources.schema.yaml")
+
+# Sample information
+samples = pd.read_table(config["samples"], dtype=str).set_index("sample", drop=False)
+validate(samples, schema="../schemas/samples.schema.yaml")
+
+units = pd.read_table(config["units"], dtype=str).set_index(["sample", "type"], drop=False)
+validate(units, schema="../schemas/units_references.schema.yaml")
+
+def compile_output_list(wildcards: snakemake.io.Wildcards):
+    return [
+        "reference_files/cnvkit.PoN.cnn",
+        # "reference_files/gatk_cnv_panel_of_normal.hdf5",
+        # "reference_files/Msisensor_pro_reference.list_baseline",
+        # "reference_files/background_panel.tsv",
+        # "reference_files/artifact_panel.tsv",
+        # "reference_files/svdb_cnv.vcf",
+        # "reference_files/normalDB_hg19.rds",
+        # "reference_files/mapping_bias_nextseq_27_hg19.rds",
+    ]

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -1,4 +1,5 @@
 import pandas as pd
+from pathlib import Path
 from snakemake.utils import validate
 from snakemake.utils import min_version
 import sys
@@ -28,6 +29,7 @@ def compile_output_list(wildcards: snakemake.io.Wildcards):
         # "reference_files/background_panel.tsv",
         # "reference_files/artifact_panel.tsv",
         "reference_files/svdb_cnv.vcf",
+        "reference_files/{}.preprocessed.interval_list".format(Path(config.get("reference", {}).get("design_bed")).name),
         # "reference_files/normalDB_hg19.rds",
         # "reference_files/mapping_bias_nextseq_27_hg19.rds",
     ]

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -27,7 +27,7 @@ def compile_output_list(wildcards: snakemake.io.Wildcards):
         # "reference_files/Msisensor_pro_reference.list_baseline",
         # "reference_files/background_panel.tsv",
         # "reference_files/artifact_panel.tsv",
-        # "reference_files/svdb_cnv.vcf",
+        "reference_files/svdb_cnv.vcf",
         # "reference_files/normalDB_hg19.rds",
         # "reference_files/mapping_bias_nextseq_27_hg19.rds",
     ]

--- a/workflow/rules/result_files_references.smk
+++ b/workflow/rules/result_files_references.smk
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 rule copy_cnvkit_references:
     input:
         "references/cnvkit_build_normal_reference/cnvkit.PoN.cnn",
@@ -8,11 +10,21 @@ rule copy_cnvkit_references:
         cp {input} {output}
         """
 
-rule copy_gatk_references:
+rule copy_gatk_pon:
     input:
         "references/create_read_count_panel_of_normals/gatk_cnv_panel_of_normal.hdf5",
     output:
         "reference_files/gatk.PoN.hdf5",
+    shell:
+        """
+        cp {input} {output}
+        """
+
+rule copy_gatk_interval_list:
+    input:
+        "references/preprocess_intervals/{}.preprocessed.interval_list".format(Path(config.get("reference", {}).get("design_bed")).name),
+    output:
+        "reference_files/{}.preprocessed.interval_list".format(Path(config.get("reference", {}).get("design_bed")).name),
     shell:
         """
         cp {input} {output}

--- a/workflow/rules/result_files_references.smk
+++ b/workflow/rules/result_files_references.smk
@@ -1,0 +1,10 @@
+rule copy_cnvkit_references:
+    input:
+        "references/cnvkit_build_normal_reference/cnvkit.PoN.cnn",
+    output:
+        "reference_files/cnvkit.PoN.cnn",
+    shell:
+        """
+        cp {input} {output}
+        """
+

--- a/workflow/rules/result_files_references.smk
+++ b/workflow/rules/result_files_references.smk
@@ -8,3 +8,12 @@ rule copy_cnvkit_references:
         cp {input} {output}
         """
 
+rule copy_svbd_references:
+    input:
+        "references/svdb_export/svdb_cnv.vcf",
+    output:
+        "reference_files/svdb_cnv.vcf",
+    shell:
+        """
+        cp {input} {output}
+        """

--- a/workflow/rules/result_files_references.smk
+++ b/workflow/rules/result_files_references.smk
@@ -8,6 +8,16 @@ rule copy_cnvkit_references:
         cp {input} {output}
         """
 
+rule copy_gatk_references:
+    input:
+        "references/create_read_count_panel_of_normals/gatk_cnv_panel_of_normal.hdf5",
+    output:
+        "reference_files/gatk.PoN.hdf5",
+    shell:
+        """
+        cp {input} {output}
+        """
+
 rule copy_svbd_references:
     input:
         "references/svdb_export/svdb_cnv.vcf",

--- a/workflow/schemas/config_references.schema.yaml
+++ b/workflow/schemas/config_references.schema.yaml
@@ -45,6 +45,8 @@ properties:
 
   cnvkit_build_normal_reference:
     type: object
+    description: >
+      config for the cnvkit_build_normal_reference rule
     properties:
       container:
         type: string
@@ -56,6 +58,34 @@ properties:
 
   cnvkit_create_targets:
     type: object
+    description: >
+      config for the cnvkit_create_targets rule
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+    required:
+      - container
+
+  svdb_build:
+    type: object
+    description: >
+      config for the svdb_build rule
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+    required:
+      - container
+
+  svdb_export:
+    type: object
+    description: >
+      config for the svdb_export rule
     properties:
       container:
         type: string
@@ -71,3 +101,5 @@ required:
   - reference
   - cnvkit_build_normal_reference
   - cnvkit_create_targets
+  - svdb_build
+  - svdb_export

--- a/workflow/schemas/config_references.schema.yaml
+++ b/workflow/schemas/config_references.schema.yaml
@@ -31,6 +31,12 @@ properties:
           bed file defining the panel design
         format: uri-reference
 
+      dict:
+        type: string
+        description: >
+          genome sequence dictionary file
+        format: uri-reference
+
       mappability:
         type: string
         description: >
@@ -40,8 +46,22 @@ properties:
     required:
       - fasta
       - design_bed
+      - dict
       - mappability
   # end reference
+  
+  bed_to_interval_list:
+    type: object
+    description: >
+      config for the bed_to_interval_list rule
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+    required:
+      - container
 
   cnvkit_build_normal_reference:
     type: object
@@ -60,6 +80,45 @@ properties:
     type: object
     description: >
       config for the cnvkit_create_targets rule
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+    required:
+      - container
+
+  collect_read_counts:
+    type: object
+    description: >
+      config for the collect_read_counts rule
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+    required:
+      - container
+
+  create_read_count_panel_of_normals:
+    type: object
+    description: >
+      config for the create_read_count_panel_of_normals rule
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+    required:
+      - container
+
+  preprocess_intervals:
+    type: object
+    description: >
+      config for the preprocess_intervals rule
     properties:
       container:
         type: string
@@ -99,7 +158,11 @@ required:
   - resources
   - default_container
   - reference
+  - bed_to_interval_list
   - cnvkit_build_normal_reference
   - cnvkit_create_targets
+  - collect_read_counts
+  - create_read_count_panel_of_normals
+  - preprocess_intervals
   - svdb_build
   - svdb_export

--- a/workflow/schemas/config_references.schema.yaml
+++ b/workflow/schemas/config_references.schema.yaml
@@ -1,0 +1,49 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+description: snakemake configuration file
+type: object
+properties:
+  resources:
+    type: string
+    description: >
+      path to yaml file containing compute resource configuration
+    format: uri-reference
+
+  default_container:
+    type: string
+    description: >
+      uri pointing to default docker/apptainer image that should be used
+    format: uri-reference
+
+  reference:
+    type: object
+    description: >
+      reference genome files
+    properties:
+      fasta:
+        type: string
+        description: >
+          genomic fasta file
+        format: uri-reference
+
+      design_bed:
+        type: string
+        description: >
+          bed file defining the panel design
+        format: uri-reference
+
+      mappability:
+        type: string
+        description: >
+          fasta mappability file
+        format: uri-reference
+
+    required:
+      - fasta
+      - design_bed
+      - mappability
+  # end reference
+
+required:
+  - resources
+  - default_container
+  - reference

--- a/workflow/schemas/config_references.schema.yaml
+++ b/workflow/schemas/config_references.schema.yaml
@@ -43,7 +43,31 @@ properties:
       - mappability
   # end reference
 
+  cnvkit_build_normal_reference:
+    type: object
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+    required:
+      - container
+
+  cnvkit_create_targets:
+    type: object
+    properties:
+      container:
+        type: string
+        description: >
+          uri pointing to docker/apptainer image that should be used
+        format: uri-reference
+    required:
+      - container
+
 required:
   - resources
   - default_container
   - reference
+  - cnvkit_build_normal_reference
+  - cnvkit_create_targets

--- a/workflow/schemas/units_references.schema.yaml
+++ b/workflow/schemas/units_references.schema.yaml
@@ -5,15 +5,23 @@ properties:
     type: string
     description: sample id
     pattern: "^[a-zA-Z0-9-]+$"
+
   type:
     type: string
     description: >
       type of sample data Tumor, Normal, RNA (N|T|R)
     pattern: "^(N|T|R)$"
+
   bam:
     type: string
     description: >
       path to bam file
+    format: uri-reference
+
+  cnv_vcf:
+    type: string
+    description: >
+      path to cnv vcf file
     format: uri-reference
       # platform:
       #   type: string
@@ -43,6 +51,7 @@ required:
   - sample
   - type
   - bam
+  - cnv_vcf
     # - platform
     # - machine
     # - flowcell

--- a/workflow/schemas/units_references.schema.yaml
+++ b/workflow/schemas/units_references.schema.yaml
@@ -23,39 +23,9 @@ properties:
     description: >
       path to cnv vcf file
     format: uri-reference
-      # platform:
-      #   type: string
-      #   description: sequence platform that have been used to generate data, e.g. NextSeq
-      # machine:
-      #   type: string
-      #   description: machine id
-      # flowcell:
-      #   type: string
-      #   description: flowcell id
-      # barcode:
-      #   type: string
-      #   description: flowcell barcode
-      # lane:
-      #   type: string
-      #   description: lane number
-      # fastq1:
-      #   type: string
-      #   description: absolute path to R1 fastq file
-      # fastq2:
-      #   type: string
-      #   description: absolute path to R2 fastq file
-      # adapter:
-      #   type: string
-      #   description: one or more sequence, separated by ","
+
 required:
   - sample
   - type
   - bam
   - cnv_vcf
-    # - platform
-    # - machine
-    # - flowcell
-    # - lane
-    # - fastq1
-    # - fastq2
-    # - adapter

--- a/workflow/schemas/units_references.schema.yaml
+++ b/workflow/schemas/units_references.schema.yaml
@@ -1,0 +1,52 @@
+$schema: "http://json-schema.org/draft-04/schema#"
+description: representation of an input dataset
+properties:
+  sample:
+    type: string
+    description: sample id
+    pattern: "^[a-zA-Z0-9-]+$"
+  type:
+    type: string
+    description: >
+      type of sample data Tumor, Normal, RNA (N|T|R)
+    pattern: "^(N|T|R)$"
+  bam:
+    type: string
+    description: >
+      path to bam file
+    format: uri-reference
+      # platform:
+      #   type: string
+      #   description: sequence platform that have been used to generate data, e.g. NextSeq
+      # machine:
+      #   type: string
+      #   description: machine id
+      # flowcell:
+      #   type: string
+      #   description: flowcell id
+      # barcode:
+      #   type: string
+      #   description: flowcell barcode
+      # lane:
+      #   type: string
+      #   description: lane number
+      # fastq1:
+      #   type: string
+      #   description: absolute path to R1 fastq file
+      # fastq2:
+      #   type: string
+      #   description: absolute path to R2 fastq file
+      # adapter:
+      #   type: string
+      #   description: one or more sequence, separated by ","
+required:
+  - sample
+  - type
+  - bam
+    # - platform
+    # - machine
+    # - flowcell
+    # - lane
+    # - fastq1
+    # - fastq2
+    # - adapter


### PR DESCRIPTION
This PR adds the beginnings of a reference file workflow to support the main workflow. The files that currently are generated are:

- cnvkit panel of normals
- GATK CNV panel of normals
- SVDB database