### PR TITLE
docs: fix readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
     python: "3.11"
 
 mkdocs:
-  configuration: mkdocs.yml
+  configuration: mkdocs.yaml
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
Spelling error in the config: `mkdocs.yml` instead of `mkdocs.yaml`.